### PR TITLE
Added landline numbers support feature and updated some mobile rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # phonenumber
 
+## Description
+
 golang port of node-phone
 
-phonenumber is used to normalize the mobile phone number into a E.164 format.
+phonenumber is used to normalize the mobile phone or land line number into a E.164 format.
 
 The common problem is user normally input the phone number in this way:
 
@@ -22,18 +24,50 @@ What we want is always:
 819061354467
 ```
 
-# Install
+## Installation
+Run the following command to install the package:
 ```
 go get github.com/dongri/phonenumber
 ```
 
-# Usage
+## Usage
 
-```
+### Clearing format
+In this case land line numbers will be an invalid result:
+```go
 import "github.com/dongri/phonenumber"
+
 number := phonenumber.Parse("090-6135-4467", "JP")
 fmt.Println(number)
+// Output: 9061354467
 ```
 
-# License
+In this case you can format numbers included land line numbers:
+```go
+import "github.com/dongri/phonenumber"
+
+number := phonenumber.ParseWithLandLine("+371 65 552-336", "LV")
+fmt.Println(number)
+// Output: 37165552336
+```
+
+### Get country for number
+```go
+import "github.com/dongri/phonenumber"
+
+// Get country with mobile and land line numbers
+// Let's try to get country for Latvian land line number
+includeLandLine := true
+country := phonenumber.GetISO3166ByNumber("37165552336", includeLandLine)
+fmt.Println(country.CountryName)
+// Output: Latvia
+
+// Get country with mobile numbers only
+includeLandLine = false
+country := phonenumber.GetISO3166ByNumber("37165552336", includeLandLine)
+fmt.Println(country.CountryName)
+// Output:
+```
+
+## License
 MIT

--- a/iso3166.go
+++ b/iso3166.go
@@ -1694,7 +1694,7 @@ func GetISO3166() []ISO3166 {
 	i.Alpha3 = "TUN"
 	i.CountryCode = "216"
 	i.CountryName = "Tunisia"
-	i.MobileBeginWith = []string{"2", "9"}
+	i.MobileBeginWith = []string{"2", "4", "5", "9"}
 	i.PhoneNumberLengths = []int{8}
 	iso3166Datas = append(iso3166Datas, i)
 

--- a/iso3166.go
+++ b/iso3166.go
@@ -1030,7 +1030,7 @@ func GetISO3166() []ISO3166 {
 	i.Alpha3 = "MAR"
 	i.CountryCode = "212"
 	i.CountryName = "Morocco"
-	i.MobileBeginWith = []string{"6"}
+	i.MobileBeginWith = []string{"526", "527", "533", "534", "54", "55", "6", "7"}
 	i.PhoneNumberLengths = []int{9}
 	iso3166Datas = append(iso3166Datas, i)
 

--- a/iso3166.go
+++ b/iso3166.go
@@ -839,7 +839,7 @@ func GetISO3166() []ISO3166 {
 	i.CountryCode = "39"
 	i.CountryName = "Italy"
 	i.MobileBeginWith = []string{"3"}
-	i.PhoneNumberLengths = []int{10}
+	i.PhoneNumberLengths = []int{9, 10}
 	iso3166Datas = append(iso3166Datas, i)
 
 	i.Alpha2 = "JM"

--- a/iso3166.go
+++ b/iso3166.go
@@ -154,7 +154,7 @@ func GetISO3166() []ISO3166 {
 	i.CountryCode = "43"
 	i.CountryName = "Austria"
 	i.MobileBeginWith = []string{"6"}
-	i.PhoneNumberLengths = []int{10, 11, 12, 13, 14}
+	i.PhoneNumberLengths = []int{7, 8, 9, 10, 11, 12, 13}
 	iso3166Datas = append(iso3166Datas, i)
 
 	i.Alpha2 = "AZ"

--- a/iso3166.go
+++ b/iso3166.go
@@ -486,7 +486,7 @@ func GetISO3166() []ISO3166 {
 	i.Alpha3 = "DNK"
 	i.CountryCode = "45"
 	i.CountryName = "Denmark"
-	i.MobileBeginWith = []string{"2", "30", "31", "40", "41", "42", "50", "51", "52", "53", "60", "61", "71", "81", "91", "92", "93"}
+	i.MobileBeginWith = []string{"2", "30", "31", "37", "40", "41", "42", "50", "51", "52", "53", "60", "61", "71", "81", "91", "92", "93"}
 	i.PhoneNumberLengths = []int{8}
 	iso3166Datas = append(iso3166Datas, i)
 
@@ -534,7 +534,7 @@ func GetISO3166() []ISO3166 {
 	i.Alpha3 = "ESP"
 	i.CountryCode = "34"
 	i.CountryName = "Spain"
-	i.MobileBeginWith = []string{"6", "7"}
+	i.MobileBeginWith = []string{"6", "7", "59"}
 	i.PhoneNumberLengths = []int{9}
 	iso3166Datas = append(iso3166Datas, i)
 
@@ -542,7 +542,7 @@ func GetISO3166() []ISO3166 {
 	i.Alpha3 = "EST"
 	i.CountryCode = "372"
 	i.CountryName = "Estonia"
-	i.MobileBeginWith = []string{"5", "81", "82", "83"}
+	i.MobileBeginWith = []string{"5", "81", "82", "83", "84", "85", "86", "87"}
 	i.PhoneNumberLengths = []int{7, 8}
 	iso3166Datas = append(iso3166Datas, i)
 
@@ -1102,7 +1102,7 @@ func GetISO3166() []ISO3166 {
 	i.Alpha3 = "MLT"
 	i.CountryCode = "356"
 	i.CountryName = "Malta"
-	i.MobileBeginWith = []string{"79", "99"}
+	i.MobileBeginWith = []string{"79", "99", "98", "72", "92", "77", "96"}
 	i.PhoneNumberLengths = []int{8}
 	iso3166Datas = append(iso3166Datas, i)
 

--- a/phonenumber_test.go
+++ b/phonenumber_test.go
@@ -12,7 +12,7 @@ func TestJP(t *testing.T) {
 	}
 }
 
-func TestCN(t *testing.T) {
+func TestCNFormat(t *testing.T) {
 	number := Parse("+8615948692360", "cn")
 	expected := "8615948692360"
 	if number != expected {
@@ -20,10 +20,73 @@ func TestCN(t *testing.T) {
 	}
 }
 
-func TestUSA(t *testing.T) {
+func TestUSAFormat(t *testing.T) {
 	number := Parse("(817) 569-8900", "usa")
 	expected := "18175698900"
 	if number != expected {
 		t.Errorf("CN: got %v\nwant %v", number, expected)
+	}
+}
+
+func TestLVMobileFormat(t *testing.T) {
+	number := Parse("+371 25 641 580", "lv")
+	expected := "37125641580"
+	if number != expected {
+		t.Errorf("LV mobile: got %v\nwant %v", number, expected)
+	}
+}
+
+func TestLVLandLineIsNotValid(t *testing.T) {
+	number := Parse("+371 (67) 881-727", "lv")
+	if number != "" {
+		t.Errorf("Backward compatibility fail: Parse() for land line number must be empty")
+	}
+}
+
+func TestLVLandLineFormat(t *testing.T) {
+	number := ParseWithLandLine("+371 (67) 881-727", "lv")
+	expected := "37167881727"
+	if number != expected {
+		t.Errorf("LV land line parse: got %v\nwant %v", number, expected)
+	}
+}
+
+func TestLVLandLineFormatWithMobileNumberIsEmpty(t *testing.T) {
+	number := ParseWithLandLine("+371(25)641580", "lv")
+	expected := "37125641580"
+	if number != expected {
+		t.Errorf("LV land line parse: got %v\nwant %v", number, expected)
+	}
+}
+
+func TestGetCountryForLVMobile(t *testing.T) {
+	tv := "37125641580" // mobile number
+	country := GetISO3166ByNumber(tv, true)
+	expected := getISO3166ByCountry("lv")
+	if country.CountryName == "" {
+		t.Errorf("Country is empty for Latvian mobile number %s", tv)
+	}
+	if country.CountryName != expected.CountryName {
+		t.Errorf("For Latvian mobile number %s got country %s\nwant %s", tv, country.CountryName, expected.CountryName)
+	}
+}
+
+func TestGetCountryIsEmptyForLandLineNumberInMobileOnlySearch(t *testing.T) {
+	tv := "37167881727" // land line number
+	country := GetISO3166ByNumber(tv, false)
+	if country.CountryName != "" {
+		t.Errorf("Got country %s for landline number %s for lookup through mobile only numbers, expected: not found", country.CountryName, tv)
+	}
+}
+
+func TestGetCountryForLVLandLine(t *testing.T) {
+	tv := "37167881727" // land line number
+	country := GetISO3166ByNumber(tv, true)
+	expected := getISO3166ByCountry("lv")
+	if country.CountryName == "" {
+		t.Errorf("Country is empty for Latvian land line number %s", tv)
+	}
+	if country.CountryName != expected.CountryName {
+		t.Errorf("For Latvian landline number %s got country %s\nwant %s", tv, country.CountryName, expected.CountryName)
 	}
 }

--- a/phonenumber_test.go
+++ b/phonenumber_test.go
@@ -90,3 +90,16 @@ func TestGetCountryForLVLandLine(t *testing.T) {
 		t.Errorf("For Latvian landline number %s got country %s\nwant %s", tv, country.CountryName, expected.CountryName)
 	}
 }
+
+func TestGetCountryForITMobile(t *testing.T) {
+	tv := "39335370971" // mobile number
+	expected := getISO3166ByCountry("it") // country
+
+	country := GetISO3166ByNumber(tv, true)
+	if country.CountryName == "" {
+		t.Errorf("Country is empty for %s mobile number `%s`", expected.CountryName, tv)
+	}
+	if country.CountryName != expected.CountryName {
+		t.Errorf("For `%s` mobile number `%s` got country `%s`\nwant `%s`", expected.CountryName, tv, country.CountryName, expected.CountryName)
+	}
+}

--- a/phonenumber_test.go
+++ b/phonenumber_test.go
@@ -95,7 +95,7 @@ func TestGetCountryForITMobile(t *testing.T) {
 	tv := "39339638066" // mobile number
 	expected := getISO3166ByCountry("it") // country
 
-	country := GetISO3166ByNumber(tv, true)
+	country := GetISO3166ByNumber(tv, false)
 	if country.CountryName == "" {
 		t.Errorf("Country is empty for %s mobile number `%s`", expected.CountryName, tv)
 	}
@@ -108,7 +108,20 @@ func TestGetCountryForAUTMobile(t *testing.T) {
 	tv := "43663242739" // mobile number
 	expected := getISO3166ByCountry("at") // country
 
-	country := GetISO3166ByNumber(tv, true)
+	country := GetISO3166ByNumber(tv, false)
+	if country.CountryName == "" {
+		t.Errorf("Country is empty for %s mobile number `%s`", expected.CountryName, tv)
+	}
+	if country.CountryName != expected.CountryName {
+		t.Errorf("For `%s` mobile number `%s` got country `%s`\nwant `%s`", expected.CountryName, tv, country.CountryName, expected.CountryName)
+	}
+}
+
+func TestGetCountryForTUNMobile(t *testing.T) {
+	tv := "21655886170" // mobile number
+	expected := getISO3166ByCountry("tn") // country
+
+	country := GetISO3166ByNumber(tv, false)
 	if country.CountryName == "" {
 		t.Errorf("Country is empty for %s mobile number `%s`", expected.CountryName, tv)
 	}

--- a/phonenumber_test.go
+++ b/phonenumber_test.go
@@ -92,8 +92,21 @@ func TestGetCountryForLVLandLine(t *testing.T) {
 }
 
 func TestGetCountryForITMobile(t *testing.T) {
-	tv := "39335370971" // mobile number
+	tv := "39339638066" // mobile number
 	expected := getISO3166ByCountry("it") // country
+
+	country := GetISO3166ByNumber(tv, true)
+	if country.CountryName == "" {
+		t.Errorf("Country is empty for %s mobile number `%s`", expected.CountryName, tv)
+	}
+	if country.CountryName != expected.CountryName {
+		t.Errorf("For `%s` mobile number `%s` got country `%s`\nwant `%s`", expected.CountryName, tv, country.CountryName, expected.CountryName)
+	}
+}
+
+func TestGetCountryForAUTMobile(t *testing.T) {
+	tv := "43663242739" // mobile number
+	expected := getISO3166ByCountry("at") // country
 
 	country := GetISO3166ByNumber(tv, true)
 	if country.CountryName == "" {


### PR DESCRIPTION
Landline support developed with backward compatibility: you can use `phonenumber.Parse()` as usual.
The rules have been updated based on the experience of using the package in production.