### PR TITLE
fix(land-line): land line overrides iso value due to bad loop breaking

### DIFF
--- a/phonenumber.go
+++ b/phonenumber.go
@@ -97,14 +97,13 @@ func GetISO3166ByNumber(number string, withLandLine bool) ISO3166 {
 					r := regexp.MustCompile(`^` + i.CountryCode + w)
 					if r.MatchString(number) {
 						// Match by mobile codes
-						iso3166 = i
-						break
+						return i
 					}
 				}
 
 				// Match by country code only for land line numbers only
 				if withLandLine == true {
-					iso3166 = i
+					return i
 				}
 			}
 		}


### PR DESCRIPTION
`break` in L#100 is only terminating the inner loop, making the outer loop keeps on running and override the valid value that is found before.
Returning `i` immediately when found resolves this issue