### PR TITLE
fix: Guinea mobile numbers can be 9 digits

### DIFF
--- a/iso3166.go
+++ b/iso3166.go
@@ -671,7 +671,7 @@ func populateISO3166() {
 	i.CountryCode = "224"
 	i.CountryName = "Guinea"
 	i.MobileBeginWith = []string{"6"}
-	i.PhoneNumberLengths = []int{8}
+	i.PhoneNumberLengths = []int{8, 9}
 	iso3166Datas = append(iso3166Datas, i)
 
 	i.Alpha2 = "GP"


### PR DESCRIPTION
According to the ITU, Guinea mobile phone numbers can be 9 digits: https://www.itu.int/dms_pub/itu-t/oth/02/02/T020200005B0002PDFE.pdf

This fix adds 9-digit phone numbers as a possible `PhoneNumberLengths`.