### PR TITLE
fix: allow Myanmar numbers to have have area code 9 or 09, and be 10 or 11 digits long

### DIFF
--- a/examples/main.go
+++ b/examples/main.go
@@ -3,7 +3,7 @@ package main
 import (
 	"fmt"
 
-	"github.com/dongri/phonenumber"
+	"github.com/clerk/phonenumber"
 )
 
 func main() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/dongri/phonenumber
+module github.com/clerk/phonenumber
 
 go 1.21

--- a/iso3166.go
+++ b/iso3166.go
@@ -671,7 +671,7 @@ func populateISO3166() {
 	i.CountryCode = "224"
 	i.CountryName = "Guinea"
 	i.MobileBeginWith = []string{"6"}
-	i.PhoneNumberLengths = []int{8}
+	i.PhoneNumberLengths = []int{8, 9}
 	iso3166Datas = append(iso3166Datas, i)
 
 	i.Alpha2 = "GP"

--- a/iso3166.go
+++ b/iso3166.go
@@ -1422,8 +1422,8 @@ func populateISO3166() {
 	i.Alpha3 = "PYF"
 	i.CountryCode = "689"
 	i.CountryName = "French Polynesia"
-	i.MobileBeginWith = []string{}
-	i.PhoneNumberLengths = []int{6}
+	i.MobileBeginWith = []string{"87", "88", "89"}
+	i.PhoneNumberLengths = []int{6, 8}
 	iso3166Datas = append(iso3166Datas, i)
 
 	i.Alpha2 = "QA"

--- a/iso3166.go
+++ b/iso3166.go
@@ -1134,8 +1134,8 @@ func populateISO3166() {
 	i.Alpha3 = "MMR"
 	i.CountryCode = "95"
 	i.CountryName = "Myanmar"
-	i.MobileBeginWith = []string{"9"}
-	i.PhoneNumberLengths = []int{8}
+	i.MobileBeginWith = []string{"9", "09"}
+	i.PhoneNumberLengths = []int{8, 10, 11}
 	iso3166Datas = append(iso3166Datas, i)
 
 	i.Alpha2 = "ME"

--- a/iso3166.go
+++ b/iso3166.go
@@ -1134,7 +1134,7 @@ func populateISO3166() {
 	i.Alpha3 = "MMR"
 	i.CountryCode = "95"
 	i.CountryName = "Myanmar"
-	i.MobileBeginWith = []string{"9", "09"}
+	i.MobileBeginWith = []string{"9"}
 	i.PhoneNumberLengths = []int{8, 10, 11}
 	iso3166Datas = append(iso3166Datas, i)
 

--- a/phonenumber_test.go
+++ b/phonenumber_test.go
@@ -73,6 +73,7 @@ var mobFormatTests = []struct {
 	{"+51 912 640 074", "PE", "51912640074"},
 	{"+86 18 855 512 329", "CN", "8618855512329"},
 	{"+383 4 555 4999", "XK", "38345554999"},
+	{"+224629295237", "GN", "224629295237"},
 }
 
 func TestFormatMobile(t *testing.T) {
@@ -143,6 +144,7 @@ var mobWithLLFormatTests = []struct {
 	{"+51 999 400 500", "PE", "51999400500"},
 	{"+86 (16) 855-512-329", "CN", "8616855512329"},
 	{"+383 4 1234999", "XK", "38341234999"},
+	{"+224629295237", "GN", "224629295237"},
 }
 
 func TestFormatWithLandLine(t *testing.T) {
@@ -305,6 +307,7 @@ var mobCountryTests = []struct {
 	{"51907061970", "PE", true},
 	{"8613855512329", "CN", true},
 	{"38361234999", "XK", true},
+	{"224629295237", "GN", true},
 }
 
 func TestGetCountryForMobileNumber(t *testing.T) {

--- a/phonenumber_test.go
+++ b/phonenumber_test.go
@@ -75,6 +75,7 @@ var mobFormatTests = []struct {
 	{"+383 4 555 4999", "XK", "38345554999"},
 	{"+224629295237", "GN", "224629295237"},
 	{"+68989657111", "PF", "68989657111"},
+	{"+959452929499", "MM", "959452929499"},
 }
 
 func TestFormatMobile(t *testing.T) {
@@ -147,6 +148,7 @@ var mobWithLLFormatTests = []struct {
 	{"+383 4 1234999", "XK", "38341234999"},
 	{"+224629295237", "GN", "224629295237"},
 	{"+68989657111", "PF", "68989657111"},
+	{"+959452929499", "MM", "959452929499"},
 }
 
 func TestFormatWithLandLine(t *testing.T) {
@@ -311,6 +313,7 @@ var mobCountryTests = []struct {
 	{"38361234999", "XK", true},
 	{"224629295237", "GN", true},
 	{"68989657111", "PF", true},
+	{"959452929499", "MM", true},
 }
 
 func TestGetCountryForMobileNumber(t *testing.T) {

--- a/phonenumber_test.go
+++ b/phonenumber_test.go
@@ -74,6 +74,7 @@ var mobFormatTests = []struct {
 	{"+86 18 855 512 329", "CN", "8618855512329"},
 	{"+383 4 555 4999", "XK", "38345554999"},
 	{"+224629295237", "GN", "224629295237"},
+	{"+68989657111", "PF", "68989657111"},
 }
 
 func TestFormatMobile(t *testing.T) {
@@ -145,6 +146,7 @@ var mobWithLLFormatTests = []struct {
 	{"+86 (16) 855-512-329", "CN", "8616855512329"},
 	{"+383 4 1234999", "XK", "38341234999"},
 	{"+224629295237", "GN", "224629295237"},
+	{"+68989657111", "PF", "68989657111"},
 }
 
 func TestFormatWithLandLine(t *testing.T) {
@@ -308,6 +310,7 @@ var mobCountryTests = []struct {
 	{"8613855512329", "CN", true},
 	{"38361234999", "XK", true},
 	{"224629295237", "GN", true},
+	{"68989657111", "PF", true},
 }
 
 func TestGetCountryForMobileNumber(t *testing.T) {


### PR DESCRIPTION
Checked https://dialaxy.com/blogs/myanmar-phone-number-format/ to confirm the information the customer shared.